### PR TITLE
Fixes for SWMR

### DIFF
--- a/org.eclipse.dawnsci.hdf5.test/src/org/eclipse/dawnsci/hdf5/nexus/NexusFileHDF5Test.java
+++ b/org.eclipse.dawnsci.hdf5.test/src/org/eclipse/dawnsci/hdf5/nexus/NexusFileHDF5Test.java
@@ -1,0 +1,62 @@
+/*-
+ * Copyright 2016 Diamond Light Source Ltd.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.eclipse.dawnsci.hdf5.nexus;
+
+import static org.junit.Assert.assertFalse;
+
+import ncsa.hdf.hdf5lib.H5;
+import ncsa.hdf.hdf5lib.HDF5Constants;
+
+import org.eclipse.dawnsci.analysis.api.dataset.IDataset;
+import org.eclipse.dawnsci.analysis.api.dataset.ILazyWriteableDataset;
+import org.eclipse.dawnsci.analysis.dataset.impl.Dataset;
+import org.eclipse.dawnsci.analysis.dataset.impl.DatasetFactory;
+import org.eclipse.dawnsci.analysis.dataset.impl.LazyWriteableDataset;
+import org.eclipse.dawnsci.hdf5.HDF5DatasetResource;
+import org.eclipse.dawnsci.hdf5.HDF5DatatypeResource;
+import org.eclipse.dawnsci.hdf5.HDF5FileResource;
+import org.eclipse.dawnsci.hdf5.HDF5Resource;
+import org.eclipse.dawnsci.hdf5.nexus.NexusFileHDF5;
+import org.junit.Test;
+
+public class NexusFileHDF5Test {
+
+	private final static String FILE_NAME = "test-scratch/test.nxs";
+
+	@Test
+	public void testStringsSwmrFixedLength() throws Exception {
+		IDataset ods = DatasetFactory.createFromObject(new String[] {"String 1", "String 2", "String 3"});
+		try (NexusFileHDF5 nf = new NexusFileHDF5(FILE_NAME, true)) {
+			nf.createAndOpenToWrite();
+			ILazyWriteableDataset lds = new LazyWriteableDataset("data",
+					Dataset.STRING,
+					new int[] {0},
+					new int[] {ILazyWriteableDataset.UNLIMITED},
+					new int[] {3},
+					null);
+			nf.createData("/test", lds, true);
+			nf.flush();
+		}
+		try (HDF5Resource fRes = new HDF5FileResource(H5.H5Fopen(FILE_NAME,
+					HDF5Constants.H5F_ACC_RDONLY,
+					HDF5Constants.H5P_DEFAULT));
+				HDF5Resource dRes = new HDF5DatasetResource(H5.H5Dopen(fRes.getResource(),
+						"/test/data",
+						HDF5Constants.H5P_DEFAULT));
+				HDF5Resource tRes = new HDF5DatatypeResource(H5.H5Dget_type(dRes.getResource()))) {
+			assertFalse(H5.H5Tis_variable_str(tRes.getResource()));
+		}
+		try (NexusFileHDF5 nf = new NexusFileHDF5(FILE_NAME, true)) {
+			nf.openToWrite(true);
+			ILazyWriteableDataset lds = nf.getData("/test/data").getWriteableDataset();
+			lds.setSlice(null, ods, new int[] {0}, new int[] {3}, null);
+		}
+	}
+}

--- a/org.eclipse.dawnsci.hdf5/src/org/eclipse/dawnsci/hdf5/HDF5FileFactory.java
+++ b/org.eclipse.dawnsci.hdf5/src/org/eclipse/dawnsci/hdf5/HDF5FileFactory.java
@@ -111,8 +111,14 @@ public class HDF5FileFactory {
 							if (a.count <= 0) {
 								if (a.time <= now) {
 									try {
-										if (H5.H5Fget_obj_count(a.id, HDF5Constants.H5F_OBJ_ATTR | HDF5Constants.H5F_OBJ_DATATYPE | HDF5Constants.H5F_OBJ_DATASET | HDF5Constants.H5F_OBJ_GROUP) > 0) {
-											logger.error("There are things left open in " + f);
+										int openObjects = H5.H5Fget_obj_count(a.id,
+												HDF5Constants.H5F_OBJ_LOCAL |
+												HDF5Constants.H5F_OBJ_DATASET |
+												HDF5Constants.H5F_OBJ_DATATYPE |
+												HDF5Constants.H5F_OBJ_GROUP |
+												HDF5Constants.H5F_OBJ_ATTR);
+										if (openObjects > 0) {
+											logger.error("There are " + openObjects + " hdf5 objects left open");
 										}
 										H5.H5Fclose(a.id);
 										INSTANCE.map.remove(f);

--- a/org.eclipse.dawnsci.hdf5/src/org/eclipse/dawnsci/hdf5/HDF5FileResource.java
+++ b/org.eclipse.dawnsci.hdf5/src/org/eclipse/dawnsci/hdf5/HDF5FileResource.java
@@ -1,0 +1,49 @@
+/*-
+ * Copyright © 2015 Diamond Light Source Ltd.
+ *
+ * This file is part of GDA.
+ *
+ * GDA is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License version 3 as published by the Free
+ * Software Foundation.
+ *
+ * GDA is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with GDA. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.eclipse.dawnsci.hdf5;
+
+import ncsa.hdf.hdf5lib.H5;
+import ncsa.hdf.hdf5lib.exceptions.HDF5LibraryException;
+
+import org.eclipse.dawnsci.hdf5.HDF5BaseResource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class HDF5FileResource extends HDF5BaseResource {
+
+	private static final Logger logger = LoggerFactory.getLogger(HDF5FileResource.class);
+
+	/**
+	 * Wrap the specified datatype resource identifier
+	 * @param resource datatype identifier to wrap
+	 */
+	public HDF5FileResource(long resource) {
+		super(resource);
+	}
+
+	@Override
+	public void close() {
+		try {
+			H5.H5Fclose(resource);
+		} catch (HDF5LibraryException e) {
+			logger.error("Could not close HDF5 file", e);
+		}
+	}
+
+}

--- a/org.eclipse.dawnsci.hdf5/src/org/eclipse/dawnsci/hdf5/HDF5GroupResource.java
+++ b/org.eclipse.dawnsci.hdf5/src/org/eclipse/dawnsci/hdf5/HDF5GroupResource.java
@@ -1,0 +1,50 @@
+/*-
+ * Copyright © 2015 Diamond Light Source Ltd.
+ *
+ * This file is part of GDA.
+ *
+ * GDA is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License version 3 as published by the Free
+ * Software Foundation.
+ *
+ * GDA is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with GDA. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.eclipse.dawnsci.hdf5;
+
+import ncsa.hdf.hdf5lib.H5;
+import ncsa.hdf.hdf5lib.exceptions.HDF5LibraryException;
+
+import org.eclipse.dawnsci.hdf5.HDF5BaseResource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class HDF5GroupResource extends HDF5BaseResource {
+
+	private static final Logger logger = LoggerFactory.getLogger(HDF5GroupResource.class);
+
+	/**
+	 * Wrap the specified dataset resource identifier
+	 * @param resource dataset identifier to wrap
+	 */
+	public HDF5GroupResource(long resource) {
+		super(resource);
+	}
+
+	@Override
+	public void close() {
+		try {
+			H5.H5Gclose(resource);
+		} catch (HDF5LibraryException e) {
+			logger.error("Could not close HDF5 dataset", e);
+		}
+	}
+
+}
+

--- a/org.eclipse.dawnsci.hdf5/src/org/eclipse/dawnsci/hdf5/HDF5Utils.java
+++ b/org.eclipse.dawnsci.hdf5/src/org/eclipse/dawnsci/hdf5/HDF5Utils.java
@@ -1241,10 +1241,37 @@ public class HDF5Utils {
 
 					hdfMemspaceId = H5.H5Screate_simple(rank, HDF5Utils.toLongArray(data.getShape()), null);
 					if (dtype == Dataset.STRING) {
+						boolean vlenString = false;
+						hdfDatatypeId = H5.H5Dget_type(hdfDatasetId);
+						int typeSize = -1;
+						try {
+							typeSize = H5.H5Tget_size(hdfDatatypeId);
+							vlenString = H5.H5Tis_variable_str(hdfDatatypeId);
+						} finally {
+							H5.H5Tclose(hdfDatatypeId);
+							hdfDatatypeId = -1;
+						}
 						hdfDatatypeId = H5.H5Tcopy(memtype);
 						H5.H5Tset_cset(hdfDatatypeId, HDF5Constants.H5T_CSET_UTF8);
-						H5.H5Tset_size(hdfDatatypeId, HDF5Constants.H5T_VARIABLE);
-						H5.H5DwriteString(hdfDatasetId, hdfDatatypeId, hdfMemspaceId, hdfDataspaceId, HDF5Constants.H5P_DEFAULT, (String[]) buffer);
+						H5.H5Tset_size(hdfDatatypeId, vlenString ? HDF5Constants.H5T_VARIABLE : typeSize);
+						if (vlenString) {
+							H5.H5DwriteString(hdfDatasetId, hdfDatatypeId, hdfMemspaceId, hdfDataspaceId, HDF5Constants.H5P_DEFAULT, (String[]) buffer);
+						} else {
+							String[] strings = (String[]) buffer;
+							byte[] strBuffer = new byte[typeSize * strings.length];
+							int idx = 0;
+							for (String str : (String[]) strings) {
+								//typesize - 1 since we always want to leave room for \0 at the end of the string
+								if (str.length() > typeSize - 1) {
+									logger.warn("String does not fit into space allocated in HDF5 file in " + dataPath + " - string will be truncated");
+								}
+								byte[] src = str.getBytes(UTF8);
+								int length = Math.min(typeSize - 1, src.length);
+								System.arraycopy(src, 0, strBuffer, idx, length);
+								idx += typeSize;
+							}
+							H5.H5Dwrite(hdfDatasetId, hdfDatatypeId, hdfMemspaceId, hdfDataspaceId, HDF5Constants.H5P_DEFAULT, strBuffer);
+						}
 					} else {
 						H5.H5Dwrite(hdfDatasetId, memtype, hdfMemspaceId, hdfDataspaceId, HDF5Constants.H5P_DEFAULT, buffer);
 					}

--- a/org.eclipse.dawnsci.nexus.test/src/org/eclipse/dawnsci/nexus/NexusFileTest.java
+++ b/org.eclipse.dawnsci.nexus.test/src/org/eclipse/dawnsci/nexus/NexusFileTest.java
@@ -1011,4 +1011,24 @@ public class NexusFileTest {
 
 		assertFalse(readH == readL);
 	}
+
+	@Test
+	public void testLazyWriteFromReadbackNode() throws Exception {
+		nf.close();
+		IDataset ods = DatasetFactory.createFromObject(new int[] {10, 20, 30});
+		try (NexusFile nf2 = NexusTestUtils.createNexusFile(FILE_NAME)) {
+			ILazyWriteableDataset lds = new LazyWriteableDataset("data",
+					Dataset.INT32,
+					new int[] {0},
+					new int[] {ILazyWriteableDataset.UNLIMITED},
+					new int[] {3},
+					null);
+			nf2.createData("/test/", lds, true);
+			nf2.flush();
+		}
+		try (NexusFile nf = NexusTestUtils.openNexusFile((FILE_NAME))) {
+			ILazyWriteableDataset lds = nf.getData("/test/data").getWriteableDataset();
+			lds.setSlice(null, ods, new int[] {0}, new int[] {3}, null);
+		}
+	}
 }


### PR DESCRIPTION
The HDF5 library does not support use of SWMR with datasets of variable length types.
If we are creating a file for use with SWMR writing, any string datasets should be fixed-length.