### PR TITLE
Fix getAxes to always order axis datasets over non-axis datasets

### DIFF
--- a/org.eclipse.dawnsci.hdf5/src/org/eclipse/dawnsci/hdf5/nexus/NexusUtils.java
+++ b/org.eclipse.dawnsci.hdf5/src/org/eclipse/dawnsci/hdf5/nexus/NexusUtils.java
@@ -299,7 +299,9 @@ public class NexusUtils {
         final String parentPath = signal.getFullName().substring(0, signal.getFullName().lastIndexOf("/"));
         
         final Group parent = (Group)file.get(parentPath);
-        
+
+        int fakePosValue = Integer.MAX_VALUE;
+
         final List<HObject> children = parent.getMemberList();
 		for (HObject hObject : children) {
 			final List<?> att = hObject.getMetadata();
@@ -344,7 +346,12 @@ public class NexusUtils {
 					}
 				}
 			}
-			
+
+			//prioritise datasets that specify an axes (even with no primary attribute) over other datasets
+			if (axis != null && pos == -1) {
+				pos = fakePosValue--;
+			}
+
 			// Add any the same shape as this dimension
 			// providing that they are not signals
 			// Some nexus files set axis wrong


### PR DESCRIPTION
Axes that specify a primary are always weighted above ones that don't.

Signed-off-by: Charles Mita <charles.mita@diamond.ac.uk>