### PR TITLE
Add new skew strategy for estimating chunking and make default

### DIFF
--- a/org.eclipse.dawnsci.nexus/src/org/eclipse/dawnsci/nexus/NexusUtils.java
+++ b/org.eclipse.dawnsci.nexus/src/org/eclipse/dawnsci/nexus/NexusUtils.java
@@ -10,6 +10,7 @@
 
 package org.eclipse.dawnsci.nexus;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 
@@ -31,6 +32,27 @@ import org.eclipse.dawnsci.analysis.tree.impl.TreeFileImpl;
  * Utility methods for dealing with NeXus files.
  */
 public class NexusUtils {
+
+	final static int CHUNK_TARGET_SIZE = 1024 * 1024; // 1 MB
+
+	final static ChunkingStrategy DEFAULT_CHUNK_STRATEGY = ChunkingStrategy.SKEW_LAST;
+
+	/**
+	 * Possible strategies for estimating chunking
+	 */
+	public enum ChunkingStrategy {
+		/**
+		 * Approximately balance chunking across all dimensions
+		 * Better for slicing across multiple dimensions when processing.
+		 */
+		BALANCE,
+
+		/**
+		 * Skew chunking toward later dimensions - maximally reduce earlier dimensions first
+		 * Good for writing large detector images frame by frame.
+		 */
+		SKEW_LAST
+	}
 
 	/**
 	 * Create a (top-level) NeXus augmented path
@@ -342,19 +364,10 @@ public class NexusUtils {
 		}
 	}
 
-	/**
-	 * Estimate suitable chunking parameters based on the expected final size of a dataset
-	 *
-	 * @param expectedMaxShape
-	 *            expected final size of the dataset
-	 * @param dataByteSize
-	 *            size of each element in bytes
-	 * @param fixedChunkDimensions
-	 *            provided dimensions in a chunk to be kept constant (-1 for no provided chunk)
-	 * @return chunking estimate
-	 */
-	public static int[] estimateChunking(int[] expectedMaxShape, int dataByteSize, int[] fixedChunkDimensions) {
-		final long targetSize = 1024 * 1024;
+	private static int[] estimateChunkingBalanced(int[] expectedMaxShape,
+			int dataByteSize,
+			int[] fixedChunkDimensions,
+			int targetSize) {
 		if (expectedMaxShape == null) {
 			throw new NullPointerException("Must provide an expected shape");
 		}
@@ -407,16 +420,126 @@ public class NexusUtils {
 		return chunks;
 	}
 
+	private static int[] estimateChunkingSkewed(int[] expectedMaxShape,
+			int dataByteSize,
+			int[] fixedChunkDimensions,
+			int targetSize) {
+		if (expectedMaxShape == null) {
+			throw new NullPointerException("Must provide an expected shape");
+		}
+		if (fixedChunkDimensions != null && (expectedMaxShape.length != fixedChunkDimensions.length)) {
+			throw new IllegalArgumentException("Shape estimation and provided chunk information have different dimensions");
+		}
+		for (int d : expectedMaxShape) {
+			if (d <= 0) {
+				throw new IllegalArgumentException("Shape estimation must have dimensions greater than zero");
+			}
+		}
+
+		int[] chunk = Arrays.copyOf(expectedMaxShape, expectedMaxShape.length);
+		int[] fixed = fixedChunkDimensions;
+		if (fixed == null) {
+			fixed = new int[chunk.length];
+			Arrays.fill(fixed, -1);
+		}
+		for (int i = 0; i < chunk.length; i++) {
+			if (fixed[i] > 0) {
+				chunk[i] = fixed[i];
+			}
+		}
+		long currentSize = dataByteSize;
+		for (int i : chunk) {
+			currentSize *= (long) i;
+		}
+		ArrayList<Integer> toReduce = new ArrayList<Integer>();
+		for (int i = 0; i < fixed.length; i++) {
+			if (fixed[i] < 1) toReduce.add(i);
+		}
+		outer_loop:
+		for (int idx : toReduce) {
+			while (chunk[idx] > 1) {
+				if (currentSize > targetSize) {
+					// round up to avoid needing an extra chunk to hold a tiny amount of data
+					chunk[idx] = (int) Math.ceil(chunk[idx] / 2.0);
+
+					currentSize = dataByteSize;
+					for (int c : chunk) {
+						currentSize *= (long) c;
+					}
+				} else {
+					// finished reducing chunk
+					break outer_loop;
+				}
+			}
+		}
+		return chunk;
+	}
+
 	/**
-	 * Estimate suitable chunking paremeters based on the expected final size of a dataset
+	 * Estimate suitable chunk parameters based on the expected final size of a dataset
 	 *
 	 * @param expectedMaxShape
 	 *            expected final size of the dataset
 	 * @param dataByteSize
 	 *            size of each element in bytes
-	 * @return chunking estimate
+	 * @param fixedChunkDimensions
+	 *            provided dimensions in a chunk to be kept constant (-1 for no provided chunk)
+	 * @param strategy
+	 *            strategy to use for estimating
+	 * @return chunk estimate
+	 */
+	public static int[] estimateChunking(int[] expectedMaxShape,
+			int dataByteSize,
+			int[] fixedChunkDimensions,
+			ChunkingStrategy strategy) {
+		switch (strategy) {
+		case BALANCE:
+			return estimateChunkingBalanced(expectedMaxShape, dataByteSize, fixedChunkDimensions, CHUNK_TARGET_SIZE);
+		case SKEW_LAST:
+		default:
+			return estimateChunkingSkewed(expectedMaxShape, dataByteSize, fixedChunkDimensions, CHUNK_TARGET_SIZE);
+		}
+	}
+
+	/**
+	 * Estimate suitable chunk parameters based on the expected final size of a dataset
+	 * @param expectedMaxShape
+	 *            expected final size of the dataset
+	 * @param dataByteSize
+	 *            size of each element in bytes
+	 * @param strategy
+	 *            strategy to use for estimating
+	 * @return chunk estimate
+	 */
+	public static int[] estimateChunking(int[] expectedMaxShape, int dataByteSize, ChunkingStrategy strategy) {
+		return estimateChunking(expectedMaxShape, dataByteSize, null, strategy);
+	}
+
+	/**
+	 * Estimate suitable chunk parameters based on the expected final size of a dataset
+	 *
+	 * @param expectedMaxShape
+	 *            expected final size of the dataset
+	 * @param dataByteSize
+	 *            size of each element in bytes
+	 * @param fixedChunkDimensions
+	 *            provided dimensions in a chunk to be kept constant (-1 for no provided chunk)
+	 * @return chunk estimate
+	 */
+	public static int[] estimateChunking(int[] expectedMaxShape, int dataByteSize, int[] fixedChunkDimensions) {
+		return estimateChunking(expectedMaxShape, dataByteSize, fixedChunkDimensions, DEFAULT_CHUNK_STRATEGY);
+	}
+
+	/**
+	 * Estimate suitable chunk parameters based on the expected final size of a dataset
+	 *
+	 * @param expectedMaxShape
+	 *            expected final size of the dataset
+	 * @param dataByteSize
+	 *            size of each element in bytes
+	 * @return chunk estimate
 	 */
 	public static int[] estimateChunking(int[] expectedMaxShape, int dataByteSize) {
-		return estimateChunking(expectedMaxShape, dataByteSize, null);
+		return estimateChunking(expectedMaxShape, dataByteSize, null, DEFAULT_CHUNK_STRATEGY);
 	}
 }


### PR DESCRIPTION
The original strategy produced a chunk that was balanced according to
the expected data dimensions - this is reasonable if processors are
likely to slice over different dimensions but it is not so good for
writing or processing single detector images at a time.

The new strategy ("skew") weights the chunk dimensions toward the last
dimensions, reducing earlier dimensions to one before moving to the next
(or until the chunk is under the target size - usually 1MB).

This is made the default as it is more likely to cater for the common
case when people forget to specify chunking.

Signed-off-by: Charles Mita <charles.mita@diamond.ac.uk>