### PR TITLE
Ensure first point of PolylineROI's point list stays in sync with spt

### DIFF
--- a/org.eclipse.dawnsci.analysis.dataset/src/org/eclipse/dawnsci/analysis/dataset/roi/PolylineROI.java
+++ b/org.eclipse.dawnsci.analysis.dataset/src/org/eclipse/dawnsci/analysis/dataset/roi/PolylineROI.java
@@ -83,6 +83,8 @@ public class PolylineROI extends ROIBase implements IPolylineROI, Serializable {
 		super.setPoint(point.spt);
 		if (pts.size() == 0) {
 			pts.add(point);
+		} else {
+			pts.set(0, point);
 		}
 	}
 


### PR DESCRIPTION
This fixes a bug seen in the GDA client where the ROI given by a
ROIChanged event had an incorrect first point.

Signed-off-by: Colin Palmer <colin.palmer@diamond.ac.uk>