### PR TITLE
Prefer ASCII strings in NexusFileHDF5.

### DIFF
--- a/org.eclipse.dawnsci.hdf5/src/org/eclipse/dawnsci/hdf5/HDF5Utils.java
+++ b/org.eclipse.dawnsci.hdf5/src/org/eclipse/dawnsci/hdf5/HDF5Utils.java
@@ -1274,15 +1274,17 @@ public class HDF5Utils {
 						boolean vlenString = false;
 						hdfDatatypeId = H5.H5Dget_type(hdfDatasetId);
 						int typeSize = -1;
+						int cset = HDF5Constants.H5T_CSET_ASCII;
 						try {
 							typeSize = (int) H5.H5Tget_size(hdfDatatypeId);
 							vlenString = H5.H5Tis_variable_str(hdfDatatypeId);
+							cset = H5.H5Tget_cset(hdfDatatypeId);
 						} finally {
 							H5.H5Tclose(hdfDatatypeId);
 							hdfDatatypeId = -1;
 						}
 						hdfDatatypeId = H5.H5Tcopy(memtype);
-						H5.H5Tset_cset(hdfDatatypeId, HDF5Constants.H5T_CSET_UTF8);
+						H5.H5Tset_cset(hdfDatatypeId, cset);
 						H5.H5Tset_size(hdfDatatypeId, vlenString ? HDF5Constants.H5T_VARIABLE : typeSize);
 						if (vlenString) {
 							H5.H5Dwrite_VLStrings(hdfDatasetId, hdfDatatypeId, hdfMemspaceId, hdfDataspaceId, HDF5Constants.H5P_DEFAULT, (String[]) buffer);

--- a/org.eclipse.dawnsci.hdf5/src/org/eclipse/dawnsci/hdf5/nexus/NexusFileHDF5.java
+++ b/org.eclipse.dawnsci.hdf5/src/org/eclipse/dawnsci/hdf5/nexus/NexusFileHDF5.java
@@ -902,7 +902,7 @@ public class NexusFileHDF5 implements NexusFile {
 					}
 				}
 				if (stringDataset) {
-					H5.H5Tset_cset(hdfDatatypeId, HDF5Constants.H5T_CSET_UTF8);
+					H5.H5Tset_cset(hdfDatatypeId, HDF5Constants.H5T_CSET_ASCII);
 					H5.H5Tset_size(hdfDatatypeId, writeVlenString ? HDF5Constants.H5T_VARIABLE : DEF_FIXED_STRING_LENGTH);
 				} else if (fillValue != null) {
 					//Strings must not have a fill value set


### PR DESCRIPTION
h5py has various issues with unicode strings.
Also changes H5Utils to match the character set when writing a dataset
slice.

Signed-off-by: Charles Mita <charles.mita@diamond.ac.uk>