### PR TITLE
Do not overwrite target attribute on hard links

### DIFF
--- a/org.eclipse.dawnsci.hdf5/src/org/eclipse/dawnsci/hdf5/nexus/NexusFileHDF5.java
+++ b/org.eclipse.dawnsci.hdf5/src/org/eclipse/dawnsci/hdf5/nexus/NexusFileHDF5.java
@@ -1176,7 +1176,6 @@ public class NexusFileHDF5 implements NexusFile {
 				throw new NullPointerException("Attribute must have a name");
 			}
 			Node node = getNode(path, false).node;
-			node.addAttribute(attr);
 			try {
 				//if an attribute with the same name already exists, we delete it to be consistent with NAPI
 				if (H5.H5Aexists_by_name(fileId, path, attrName, HDF5Constants.H5P_DEFAULT)) {
@@ -1235,6 +1234,7 @@ public class NexusFileHDF5 implements NexusFile {
 						}
 					}
 				}
+				node.addAttribute(attr);
 			} catch (HDF5Exception e) {
 				throw new NexusException("Could not create attribute", e);
 			}

--- a/org.eclipse.dawnsci.hdf5/src/org/eclipse/dawnsci/hdf5/nexus/NexusFileHDF5.java
+++ b/org.eclipse.dawnsci.hdf5/src/org/eclipse/dawnsci/hdf5/nexus/NexusFileHDF5.java
@@ -1301,7 +1301,9 @@ public class NexusFileHDF5 implements NexusFile {
 		IDataset target = DatasetFactory.createFromObject(source);
 		target.setName("target");
 		Attribute targetAttr = createAttribute(target);
-		addAttribute(linkName, targetAttr);
+		if (!sourceData.node.containsAttribute("target")) {
+			addAttribute(linkName, targetAttr);
+		}
 	}
 
 	private void createExternalLink(String externalFileName, String destinationParent, String linkNodeName, String source) throws NexusException {

--- a/org.eclipse.dawnsci.nexus.test/src/org/eclipse/dawnsci/nexus/file/NexusFileTest.java
+++ b/org.eclipse.dawnsci.nexus.test/src/org/eclipse/dawnsci/nexus/file/NexusFileTest.java
@@ -1164,4 +1164,29 @@ public class NexusFileTest {
 		assertTrue(readEg.containsGroupNode("a"));
 		assertEquals(data, nf.getData(readG, "ed").getDataset().getSlice());
 	}
+
+	@Test
+	public void testHardLinkWithExistingTargetAttribute() throws Exception {
+		// test that creating a hard link does not overwrite an already set "target" attribute
+		IDataset target = DatasetFactory.createFromObject("/g/d");
+		target.setName("target");
+		GroupNode h = nf.getGroup("/g/h/", true);
+		Attribute t = nf.createAttribute(target);
+		nf.addAttribute(h, t);
+		nf.link("/g/h", "/g/d"); // would normally set target to /g/h
+		GroupNode d = nf.getGroup("/g/d", false);
+		IDataset readBack = d.getAttribute("target").getValue();
+		if (readBack.getRank() == 0) {
+			readBack.resize(new int[] {1});
+		}
+		assertEquals(target, readBack.getSlice());
+		nf.close();
+		nf.openToRead();
+		d = nf.getGroup("/g/d", false);
+		readBack = d.getAttribute("target").getValue();
+		if (readBack.getRank() == 0) {
+			readBack.resize(new int[] {1});
+		}
+		assertEquals(target, readBack.getSlice());
+	}
 }


### PR DESCRIPTION
Creating a hard link will automatically create an attribute called "target" that records the original location (for compatibility with NAPI). This would overwrite an existing "target", which may be specified ahead of time, particularly if you're passing a node tree to save to disk and want a specific location to count as the "original" (the order of creation is unspecified when passing a tree).