### PR TITLE
Matthew Webber said that junit should be 4.12 minimum because 4.10

### DIFF
--- a/org.eclipse.dawnsci.analysis.examples/META-INF/MANIFEST.MF
+++ b/org.eclipse.dawnsci.analysis.examples/META-INF/MANIFEST.MF
@@ -10,6 +10,6 @@ Require-Bundle: org.eclipse.dawnsci.analysis.api;bundle-version="1.0.0",
  org.apache.commons.math3;bundle-version="[3.2.0,4.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-ActivationPolicy: lazy
-Import-Package: org.junit;version="[4.10.0,5.0.0)",
+Import-Package: org.junit;version="[4.12.0,5.0.0)",
  org.osgi.framework;version="1.7.0"
 Service-Component: OSGI-INF/*.xml 

--- a/org.eclipse.dawnsci.hdf5.model.test/META-INF/MANIFEST.MF
+++ b/org.eclipse.dawnsci.hdf5.model.test/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: org.eclipse.dawnsci.hdf5.model.test
 Bundle-Version: 1.0.0.qualifier
 Fragment-Host: org.eclipse.dawnsci.hdf5.model;bundle-version="1.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
-Require-Bundle: org.junit;bundle-version="[4.10.0,5.0.0)",
+Require-Bundle: org.junit;bundle-version="[4.12.0,5.0.0)",
  org.eclipse.dawnsci.analysis.dataset;bundle-version="1.0.0",
  org.eclipse.dawnsci.analysis.api;bundle-version="1.0.0",
  org.mockito;bundle-version="1.9.5",

--- a/org.eclipse.dawnsci.hdf5.test/META-INF/MANIFEST.MF
+++ b/org.eclipse.dawnsci.hdf5.test/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: org.eclipse.dawnsci.hdf5.test
 Bundle-Version: 1.2.0.qualifier
 Bundle-Vendor: ESRF
 Fragment-Host: org.eclipse.dawnsci.hdf5
-Require-Bundle: org.junit;bundle-version="[4.10.0,5.0.0)",
+Require-Bundle: org.junit;bundle-version="[4.12.0,5.0.0)",
  org.objenesis;bundle-version="1.0.0",
  org.mockito;bundle-version="1.9.5"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/org.eclipse.dawnsci.json.test/META-INF/MANIFEST.MF
+++ b/org.eclipse.dawnsci.json.test/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: org.eclipse.dawnsci.json.test
 Bundle-Version: 1.0.0.qualifier
 Fragment-Host: org.eclipse.dawnsci.json;bundle-version="1.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Require-Bundle: org.junit;bundle-version="4.10.0",
+Require-Bundle: org.junit;bundle-version="4.12.0",
  org.eclipse.dawnsci.analysis.dataset,
  org.mockito;bundle-version="1.9.5",
  org.objenesis;bundle-version="1.0.0"

--- a/org.eclipse.dawnsci.nexus.test/META-INF/MANIFEST.MF
+++ b/org.eclipse.dawnsci.nexus.test/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: org.eclipse.dawnsci.nexus.test
 Bundle-Version: 1.0.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Service-Component: OSGI-INF/*.xml
-Require-Bundle: org.junit;bundle-version="[4.10.0,5.0.0)",
+Require-Bundle: org.junit;bundle-version="[4.12.0,5.0.0)",
  org.eclipse.dawnsci.nexus;bundle-version="1.0.0",
  org.eclipse.dawnsci.hdf5;bundle-version="1.3.0",
  org.eclipse.dawnsci.analysis.api;bundle-version="1.0.0",

--- a/org.eclipse.dawnsci.remotedataset.test/META-INF/MANIFEST.MF
+++ b/org.eclipse.dawnsci.remotedataset.test/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: org.eclipse.dawnsci.remotedataset.test;singleton:=true
 Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: Diamond Light Source
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
-Require-Bundle: org.junit;bundle-version="4.10.0",
+Require-Bundle: org.junit;bundle-version="4.12.0",
  org.eclipse.core.filesystem;bundle-version="1.3.200",
  org.eclipse.ui;bundle-version="3.8.2",
  org.eclipse.core.runtime;bundle-version="3.8.0",


### PR DESCRIPTION
bundles hamcrest.