### PR TITLE
Remove compare on endpt in equals method

### DIFF
--- a/org.eclipse.dawnsci.analysis.dataset/src/org/eclipse/dawnsci/analysis/dataset/roi/LinearROI.java
+++ b/org.eclipse.dawnsci.analysis.dataset/src/org/eclipse/dawnsci/analysis/dataset/roi/LinearROI.java
@@ -434,8 +434,6 @@ public class LinearROI extends OrientableROIBase implements IParametricROI, Seri
 		LinearROI other = (LinearROI) obj;
 		if (crossHair != other.crossHair)
 			return false;
-		if (!Arrays.equals(ept, other.ept))
-			return false;
 		if (Double.doubleToLongBits(len) != Double.doubleToLongBits(other.len))
 			return false;
 		return true;


### PR DESCRIPTION
The endpt is a transient variable and shouldn't have been added in the auto generated equals method