### PR TITLE
Incrementally test link path in NexusFileHDF5 when validating.

### DIFF
--- a/org.eclipse.dawnsci.hdf5/src/org/eclipse/dawnsci/hdf5/nexus/NexusFileHDF5.java
+++ b/org.eclipse.dawnsci.hdf5/src/org/eclipse/dawnsci/hdf5/nexus/NexusFileHDF5.java
@@ -1460,7 +1460,17 @@ public class NexusFileHDF5 implements NexusFile {
 	@Override
 	public boolean isPathValid(String path) {
 		try {
-			return H5.H5Lexists(fileId, path, HDF5Constants.H5P_DEFAULT);
+			path = NexusUtils.stripAugmentedPath(path);
+			ParsedNode[] nodes = parseAugmentedPath(path);
+			StringBuilder partialPath = new StringBuilder();
+			for (int i = 1; i < nodes.length; i++) {
+				partialPath.append(Node.SEPARATOR);
+				partialPath.append(nodes[i].name);
+				if (!H5.H5Lexists(fileId, partialPath.toString(), HDF5Constants.H5P_DEFAULT)) {
+					return false;
+				}
+			}
+			return true;
 		} catch (HDF5LibraryException e) {
 			return false;
 		}


### PR DESCRIPTION
H5Lexists "fails" if any part of the path to test does not exist (except
the last name). Whilst we can catch the resulting exception and just
return false, this can result in a noisy message being printed to stderr
by the library, which we would like to avoid.

We follow the recommendation in the HDF5 reference to test the path
incrementally.