### PR TITLE
Revert "Remove public access to metadata constructors"

### DIFF
--- a/org.eclipse.january/src/org/eclipse/january/metadata/internal/AxesMetadataImpl.java
+++ b/org.eclipse.january/src/org/eclipse/january/metadata/internal/AxesMetadataImpl.java
@@ -32,7 +32,7 @@ public class AxesMetadataImpl implements AxesMetadata {
 	
 	Map<Integer,int[]> dimensionMap;
 
-	AxesMetadataImpl() {
+	public AxesMetadataImpl() {
 	}
 
 	@Override

--- a/org.eclipse.january/src/org/eclipse/january/metadata/internal/DimensionMetadataImpl.java
+++ b/org.eclipse.january/src/org/eclipse/january/metadata/internal/DimensionMetadataImpl.java
@@ -20,7 +20,7 @@ public class DimensionMetadataImpl implements DimensionMetadata {
 	private int[] maxShape;
 	private int[] chunkShape;
 
-	DimensionMetadataImpl() {
+	public DimensionMetadataImpl() {
 	}
 
 	@Override

--- a/org.eclipse.january/src/org/eclipse/january/metadata/internal/ErrorMetadataImpl.java
+++ b/org.eclipse.january/src/org/eclipse/january/metadata/internal/ErrorMetadataImpl.java
@@ -47,7 +47,7 @@ public class ErrorMetadataImpl implements ErrorMetadata, Serializable {
 	 * Do not use this constructor to set errors to datasets as it does not allow any shaping
 	 * checking and broadcasting. Use {@link ILazyDataset#setError(Serializable)} instead.
 	 */
-	ErrorMetadataImpl() {
+	public ErrorMetadataImpl() {
 	}
 
 	@Override

--- a/org.eclipse.january/src/org/eclipse/january/metadata/internal/MaskMetadataImpl.java
+++ b/org.eclipse.january/src/org/eclipse/january/metadata/internal/MaskMetadataImpl.java
@@ -25,7 +25,7 @@ public class MaskMetadataImpl implements MaskMetadata {
 	@Sliceable
 	IDataset mask;
 
-	MaskMetadataImpl() {
+	public MaskMetadataImpl() {
 	}
 
 	@Override

--- a/org.eclipse.january/src/org/eclipse/january/metadata/internal/OriginMetadataImpl.java
+++ b/org.eclipse.january/src/org/eclipse/january/metadata/internal/OriginMetadataImpl.java
@@ -24,8 +24,7 @@ public class OriginMetadataImpl extends DimensionMetadataImpl implements OriginM
 	private String datasetName;
 	private String filePath;
 
-	OriginMetadataImpl() {
-		super();
+	public OriginMetadataImpl() {
 	}
 
 	@Override

--- a/org.eclipse.january/src/org/eclipse/january/metadata/internal/PeemMetadataImpl.java
+++ b/org.eclipse.january/src/org/eclipse/january/metadata/internal/PeemMetadataImpl.java
@@ -18,7 +18,7 @@ public class PeemMetadataImpl implements PeemMetadata {
 	private double scaling = 512 / 50;
 	private double fieldOfView = 50;
 
-	PeemMetadataImpl() {
+	public PeemMetadataImpl() {
 	}
 
 	@Override


### PR DESCRIPTION
This reverts commit 9cbe91e8722e1a83aacf9b49080897081de769c4.