### PR TITLE
Make getFirstDiffractionMetadata do that

### DIFF
--- a/org.eclipse.dawnsci.analysis.dataset/src/org/eclipse/dawnsci/analysis/dataset/operations/AbstractOperationBase.java
+++ b/org.eclipse.dawnsci.analysis.dataset/src/org/eclipse/dawnsci/analysis/dataset/operations/AbstractOperationBase.java
@@ -183,10 +183,10 @@ public abstract class AbstractOperationBase<T extends IOperationModel, D extends
 	 */
 	public static IDiffractionMetadata getFirstDiffractionMetadata(IDataset slice) {
 
-		List<IMetadata> metaList;
+		List<IDiffractionMetadata> metaList;
 
 		try {
-			metaList = slice.getMetadata(IMetadata.class);
+			metaList = slice.getMetadata(IDiffractionMetadata.class);
 			if (metaList == null || metaList.isEmpty())
 				return null;
 		} catch (Exception e) {


### PR DESCRIPTION
Due to a change in the JaNuAry metadata handling, the helper function getFirstDiffractionMetadata does not find instances of IDiffractionMetadata, despite them being present. Searching directly for IDiffractionMetadata is not perfect, but at least it works.