### PR TITLE
Make getFirstDiffractionMetadata actually do that

### DIFF
--- a/org.eclipse.dawnsci.analysis.dataset/src/org/eclipse/dawnsci/analysis/dataset/operations/AbstractOperationBase.java
+++ b/org.eclipse.dawnsci.analysis.dataset/src/org/eclipse/dawnsci/analysis/dataset/operations/AbstractOperationBase.java
@@ -183,10 +183,10 @@ public abstract class AbstractOperationBase<T extends IOperationModel, D extends
 	 */
 	public static IDiffractionMetadata getFirstDiffractionMetadata(IDataset slice) {
 
-		List<IMetadata> metaList;
+		List<IDiffractionMetadata> metaList;
 
 		try {
-			metaList = slice.getMetadata(IMetadata.class);
+			metaList = slice.getMetadata(IDiffractionMetadata.class);
 			if (metaList == null || metaList.isEmpty())
 				return null;
 		} catch (Exception e) {


### PR DESCRIPTION
Make the Operation helper method getFirstDiffractionMetadata actually get an instance of diffraction metadata, after changes to the metadata searching in JaNuAry. Will not find IDiffractionMetadata masquerading as IMetadata.