### PR TITLE
Made ColorConstants public because can use it then without a draw2d

### DIFF
--- a/org.eclipse.dawnsci.plotting.api/src/org/eclipse/dawnsci/plotting/api/region/ColorConstants.java
+++ b/org.eclipse.dawnsci.plotting.api/src/org/eclipse/dawnsci/plotting/api/region/ColorConstants.java
@@ -18,7 +18,7 @@ import org.eclipse.swt.widgets.Display;
 /**
  * A collection of color-related constants.
  */
-interface ColorConstants {
+public interface ColorConstants {
 
 	class SystemColorFactory {
 		private static Color getColor(final int which) {


### PR DESCRIPTION
dependency.