### PR TITLE
TESTING: update testing classpath when January source checkout used

### DIFF
--- a/org.eclipse.dawnsci.analysis.dataset.test/releng.ant
+++ b/org.eclipse.dawnsci.analysis.dataset.test/releng.ant
@@ -24,8 +24,8 @@
 				<pathelement location="${workspace.git.loc}/diamond-releng.git/diamond.releng.tools/logging" />  <!-- to pick up logback-test.xml -->
 				<pathelement location="${plugin.host.basedir}/bin" />
 				<pathelement location="${plugin.host.basedir}/jars/*" />
-				<pathelement location="${workspace.git.loc}/dawnsci.git/org.eclipse.january/bin" />
-				<pathelement location="${workspace.git.loc}/dawnsci.git/org.eclipse.january.asserts/bin" />
+				<pathelement location="${workspace.git.loc}/january.git/org.eclipse.january/bin" />
+				<pathelement location="${workspace.git.loc}/january.git/org.eclipse.january.asserts/bin" />
 				<pathelement location="${workspace.git.loc}/dawnsci.git/org.eclipse.dawnsci.analysis.api/bin" />
 				<pathelement location="${workspace.git.loc}/dawnsci.git/org.eclipse.dawnsci.analysis.dataset/bin" />
 				<pathelement location="${workspace.git.loc}/dawnsci.git/org.eclipse.dawnsci.analysis.tree/bin" />

--- a/org.eclipse.dawnsci.hdf5.model.test/releng.ant
+++ b/org.eclipse.dawnsci.hdf5.model.test/releng.ant
@@ -22,7 +22,7 @@
 				<pathelement location="${plugin.basedir}/bin" />
 				<pathelement location="${workspace.git.loc}/diamond-releng.git/diamond.releng.tools/logging" />  <!-- to pick up logback-test.xml -->
 				<pathelement location="${plugin.host.basedir}/bin" />
-				<pathelement location="${workspace.git.loc}/dawnsci.git/org.eclipse.january/bin" />
+				<pathelement location="${workspace.git.loc}/january.git/org.eclipse.january/bin" />
 				<pathelement location="${workspace.git.loc}/dawnsci.git/org.eclipse.dawnsci.analysis.api/bin" />
 				<pathelement location="${workspace.git.loc}/dawnsci.git/org.eclipse.dawnsci.analysis.dataset/bin" />
 				<pathelement location="${workspace.git.loc}/dawnsci.git/org.eclipse.dawnsci.analysis.tree/bin" />

--- a/org.eclipse.dawnsci.hdf5.test/releng.ant
+++ b/org.eclipse.dawnsci.hdf5.test/releng.ant
@@ -23,8 +23,8 @@
 				<pathelement location="${plugin.basedir}/bin" />
 				<pathelement location="${workspace.git.loc}/diamond-releng.git/diamond.releng.tools/logging" />  <!-- to pick up logback-test.xml -->
 				<pathelement location="${plugin.host.basedir}/bin" />
-				<pathelement location="${workspace.git.loc}/dawnsci.git/org.eclipse.january/bin" />
-				<pathelement location="${workspace.git.loc}/dawnsci.git/org.eclipse.january.asserts/bin" />
+				<pathelement location="${workspace.git.loc}/january.git/org.eclipse.january/bin" />
+				<pathelement location="${workspace.git.loc}/january.git/org.eclipse.january.asserts/bin" />
 				<pathelement location="${workspace.git.loc}/dawnsci.git/org.eclipse.dawnsci.analysis.api/bin" />
 				<pathelement location="${workspace.git.loc}/dawnsci.git/org.eclipse.dawnsci.analysis.dataset/bin" />
 				<pathelement location="${workspace.git.loc}/dawnsci.git/org.eclipse.dawnsci.analysis.tree/bin" />

--- a/org.eclipse.dawnsci.json.test/releng.ant
+++ b/org.eclipse.dawnsci.json.test/releng.ant
@@ -23,7 +23,7 @@
 				<pathelement location="${workspace.git.loc}/diamond-releng.git/diamond.releng.tools/logging" />  <!-- to pick up logback-test.xml -->
 				<pathelement location="${plugin.host.basedir}/bin" />
 				<pathelement location="${workspace.git.loc}/daq-eclipse.git/org.eclipse.scanning.api/bin" />
-				<pathelement location="${workspace.git.loc}/dawnsci.git/org.eclipse.january/bin" />
+				<pathelement location="${workspace.git.loc}/january.git/org.eclipse.january/bin" />
 				<pathelement location="${workspace.git.loc}/dawnsci.git/org.eclipse.dawnsci.analysis.api/bin" />
 				<pathelement location="${workspace.git.loc}/dawnsci.git/org.eclipse.dawnsci.analysis.dataset/bin" />
 				<pathelement location="${workspace.git.loc}/dawnsci.git/org.eclipse.dawnsci.json/bin" />

--- a/org.eclipse.dawnsci.nexus.test/releng.ant
+++ b/org.eclipse.dawnsci.nexus.test/releng.ant
@@ -23,7 +23,7 @@
 				<pathelement location="${workspace.git.loc}/diamond-releng.git/diamond.releng.tools/logging" />  <!-- to pick up logback-test.xml -->
 				<pathelement location="${plugin.host.basedir}/bin" />
 				<pathelement location="${workspace.git.loc}/dawnsci.git/org.eclipse.dawnsci.hdf5/bin" />
-				<pathelement location="${workspace.git.loc}/dawnsci.git/org.eclipse.january/bin" />
+				<pathelement location="${workspace.git.loc}/january.git/org.eclipse.january/bin" />
 				<pathelement location="${workspace.git.loc}/dawnsci.git/org.eclipse.dawnsci.analysis.api/bin" />
 				<pathelement location="${workspace.git.loc}/dawnsci.git/org.eclipse.dawnsci.analysis.dataset/bin" />
 				<pathelement location="${workspace.git.loc}/dawnsci.git/org.eclipse.dawnsci.analysis.tree/bin" />


### PR DESCRIPTION
Normally, org.eclipse.january* is jars in the target platform,
however it is also possible to check it out as source projects.
This change supports testing in the latter case.

Signed-off-by: Matthew Webber <matthew.webber@diamond.ac.uk>