### PR TITLE
Class id clash will only raise error if new class is different.

### DIFF
--- a/org.eclipse.dawnsci.json.test/src/org/eclipse/dawnsci/json/test/JsonMarshallerClassRegistryTest.java
+++ b/org.eclipse.dawnsci.json.test/src/org/eclipse/dawnsci/json/test/JsonMarshallerClassRegistryTest.java
@@ -100,4 +100,14 @@ public class JsonMarshallerClassRegistryTest {
 		marshaller.marshal(null);
 	}
 
+	@Test
+	public void testGivenTwoClassRegistriesWithIdClashButSameReferencedClassThenNoExceptionRaised() throws Exception {
+		marshaller = new MarshallerService(new TestObjectClassRegistry(), new TestObjectAlternativeClassRegistry(), new TestObjectAlternativeClassRegistry());
+
+		ttbean.setTTReg(new TestTypeRegisteredAlternativeImpl("Registered test type."));
+		json = marshaller.marshal(ttbean);
+
+		assertJsonEquals(JSON_FOR_TTRegAltBean, json);
+	}
+
 }

--- a/org.eclipse.dawnsci.json/src/org/eclipse/dawnsci/json/internal/MarshallerServiceClassRegistry.java
+++ b/org.eclipse.dawnsci.json/src/org/eclipse/dawnsci/json/internal/MarshallerServiceClassRegistry.java
@@ -79,7 +79,7 @@ public class MarshallerServiceClassRegistry {
 
 			prevVal = idToClassMap.put(entry.getKey(), entry.getValue());
 			// prevVal stores previous value, if there is one
-			if (prevVal != null) {
+			if ((prevVal != null) && (prevVal != entry.getValue())){
 				String message = "Class id clash with registry: " + registry.toString() +
 						". Previous value for id " + entry.getKey() + " is " + prevVal +
 						". Overwriting value is: " + entry.getValue() + ".";


### PR DESCRIPTION
This is for the MarshallerService. This is due to DAWN having different
bundle dependencies, and thus requiring a separate class registry.

Signed-off-by: Martin Gaughran <martin.gaughran@diamond.ac.uk>