### PR TITLE
Increase logging, change dataholder caching behavior

### DIFF
--- a/org.eclipse.dawnsci.remotedataset.server/src/org/eclipse/dawnsci/remotedataset/server/DataServer.java
+++ b/org.eclipse.dawnsci.remotedataset.server/src/org/eclipse/dawnsci/remotedataset/server/DataServer.java
@@ -13,8 +13,6 @@ package org.eclipse.dawnsci.remotedataset.server;
 
 import java.util.HashMap;
 import java.util.Map;
-
-
 import org.eclipse.dawnsci.remotedataset.server.event.EventServlet;
 import org.eclipse.dawnsci.remotedataset.server.event.FileMonitorSocket;
 import org.eclipse.dawnsci.remotedataset.server.info.InfoServlet;
@@ -47,9 +45,6 @@ import org.eclipse.jetty.websocket.servlet.WebSocketServletFactory;
  *
  */
 public class DataServer extends PortServer {
-	
-	
-	private DataServerMode mode = DataServerMode.NORMAL;
 	
 	public DataServer() {
          	
@@ -133,7 +128,6 @@ public class DataServer extends PortServer {
 	}
 	
 	public void setMode(DataServerMode mode) {
-		this.mode = mode;
 		
 		// TODO Other diagnostic things...
 		if (mode.equals(DataServerMode.DIAGNOSTIC)) {

--- a/org.eclipse.dawnsci.remotedataset.server/src/org/eclipse/dawnsci/remotedataset/server/info/InfoServlet.java
+++ b/org.eclipse.dawnsci.remotedataset.server/src/org/eclipse/dawnsci/remotedataset/server/info/InfoServlet.java
@@ -25,6 +25,7 @@ import org.eclipse.dawnsci.analysis.api.io.ILoaderService;
 import org.eclipse.dawnsci.remotedataset.ServiceHolder;
 import org.eclipse.january.IMonitor;
 import org.eclipse.january.dataset.DTypeUtils;
+import org.eclipse.january.dataset.IDynamicDataset;
 import org.eclipse.january.dataset.ILazyDataset;
 import org.eclipse.january.metadata.DimensionMetadata;
 import org.slf4j.Logger;
@@ -100,6 +101,10 @@ public class InfoServlet extends HttpServlet {
 			final ILazyDataset lz    = dataset!=null && !"".equals(dataset)
 					                 ? holder.getLazyDataset(dataset)
 					                 : holder.getLazyDataset(0);
+
+			if (lz instanceof IDynamicDataset) {
+				((IDynamicDataset)lz).refreshShape();
+			}
 					                 
 			response.getWriter().println(lz.getName());
 			response.getWriter().println(Arrays.toString(lz.getShape()));

--- a/org.eclipse.dawnsci.remotedataset.server/src/org/eclipse/dawnsci/remotedataset/server/info/TreeServlet.java
+++ b/org.eclipse.dawnsci.remotedataset.server/src/org/eclipse/dawnsci/remotedataset/server/info/TreeServlet.java
@@ -20,13 +20,11 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.eclipse.dawnsci.analysis.api.io.IDataHolder;
-import org.eclipse.dawnsci.analysis.api.io.ILoaderService;
 import org.eclipse.dawnsci.analysis.api.persistence.IMarshallerService;
 import org.eclipse.dawnsci.analysis.api.tree.Tree;
 import org.eclipse.dawnsci.analysis.tree.TreeToMapUtils;
-import org.eclipse.dawnsci.remotedataset.ServiceHolder;
 import org.eclipse.dawnsci.remotedataset.XMLMarshallerService;
-import org.eclipse.january.IMonitor;
+import org.eclipse.dawnsci.remotedataset.server.utils.DataServerUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -95,20 +93,10 @@ public class TreeServlet extends HttpServlet {
 		final String path    = request.getParameter("path");
 		
 		try {
-			final ILoaderService lservice = ServiceHolder.getLoaderService();
-			lservice.clearSoftReferenceCache();
-			long startTime = System.currentTimeMillis();
 			
-			final IDataHolder holder = lservice.getData(path, true, new IMonitor.Stub());
+			final IDataHolder holder = DataServerUtils.getDataHolderWithLogging(path);
 			final Tree tree = holder.getTree();
 			
-			long endTime = System.currentTimeMillis()-startTime;
-			
-			if (endTime > 100 && endTime < 500) {
-				logger.info("Read of tree from {} took {} ms", path, endTime);
-			} else if (endTime >= 500) {
-				logger.warn("Read of tree from {} took {} ms", path, endTime);
-			}
 			
 			Map<String,Object> map = TreeToMapUtils.treeToMap(tree);
 			IMarshallerService mservice = new XMLMarshallerService();

--- a/org.eclipse.dawnsci.remotedataset.server/src/org/eclipse/dawnsci/remotedataset/server/slice/SliceRequest.java
+++ b/org.eclipse.dawnsci.remotedataset.server/src/org/eclipse/dawnsci/remotedataset/server/slice/SliceRequest.java
@@ -40,7 +40,7 @@ import org.eclipse.dawnsci.plotting.api.histogram.ImageServiceBean.ImageOrigin;
 import org.eclipse.dawnsci.remotedataset.Constants;
 import org.eclipse.dawnsci.remotedataset.Format;
 import org.eclipse.dawnsci.remotedataset.ServiceHolder;
-import org.eclipse.january.IMonitor;
+import org.eclipse.dawnsci.remotedataset.server.utils.DataServerUtils;
 import org.eclipse.january.dataset.IDataset;
 import org.eclipse.january.dataset.IDynamicDataset;
 import org.eclipse.january.dataset.ILazyDataset;
@@ -172,17 +172,9 @@ class SliceRequest implements HttpSessionBindingListener {
 		
 		final File   file = new File(path); // Can we see the file using the local file system?
 		if (!file.exists()) throw new IOException("Path '"+path+"' does not exist!");
-//		ServiceHolder.getLoaderService().clearSoftReferenceCache();
-		long startTime = System.currentTimeMillis();
-		final IDataHolder holder = ServiceHolder.getLoaderService().getData(path, new IMonitor.Stub()); // TOOD Make it cancellable?
+
+		final IDataHolder holder = DataServerUtils.getDataHolderWithLogging(path);
 		
-		long endTime = System.currentTimeMillis()-startTime;
-		
-		if (endTime > 100 && endTime < 500) {
-			logger.info("Read of data holder from {} took {} ms", path, endTime);
-		} else if (endTime >= 500) {
-			logger.warn("Read of data holder from {} took {} ms", path, endTime);
-		}
 		final ILazyDataset lz = dataset!=null 
 				              ? holder.getLazyDataset(dataset)
 				              : holder.getLazyDataset(0);
@@ -391,7 +383,7 @@ class SliceRequest implements HttpSessionBindingListener {
 			ostream.writeObject(data);
 			
 		} catch (Exception ne) {
-			ne.printStackTrace();
+			logger.error("Error writing object to output stream",ne);
 			throw ne;
 		} finally {
 			ostream.flush();
@@ -470,9 +462,9 @@ class SliceRequest implements HttpSessionBindingListener {
 	}
 
 	public void start() {
-		System.out.println(">>>>>> Slice Request Started");
+		logger.info(">>>>>> Slice Request Started");
 	}
 	public void stop() {
-		System.out.println(">>>>>> Slice Request Stopped");
+		logger.info(">>>>>> Slice Request Stopped");
 	}
 }

--- a/org.eclipse.dawnsci.remotedataset.server/src/org/eclipse/dawnsci/remotedataset/server/utils/DataServerUtils.java
+++ b/org.eclipse.dawnsci.remotedataset.server/src/org/eclipse/dawnsci/remotedataset/server/utils/DataServerUtils.java
@@ -1,0 +1,31 @@
+package org.eclipse.dawnsci.remotedataset.server.utils;
+
+import org.eclipse.dawnsci.analysis.api.io.IDataHolder;
+import org.eclipse.dawnsci.remotedataset.ServiceHolder;
+import org.eclipse.january.IMonitor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DataServerUtils {
+	
+	private static Logger logger = LoggerFactory.getLogger(DataServerUtils.class);
+
+	public static IDataHolder getDataHolderWithLogging(String path) throws Exception {
+		long startTime = System.currentTimeMillis();
+		final IDataHolder holder = ServiceHolder.getLoaderService().getData(path, new IMonitor.Stub()); // TOOD Make it cancellable?
+		
+		long endTime = System.currentTimeMillis()-startTime;
+		
+		long minInfo = Long.getLong("org.eclipse.dawnsci.remotedataset.server.logging.mininfo", 100);
+		long minWarn = Long.getLong("org.eclipse.dawnsci.remotedataset.server.logging.minwarn", 500);
+		
+		if (endTime > minInfo && endTime < minWarn) {
+			logger.info("Read of data holder from {} took {} ms", path, endTime);
+		} else if (endTime >= minWarn) {
+			logger.warn("Read of data holder from {} took {} ms", path, endTime);
+		}
+		
+		return holder;
+	}
+	
+}


### PR DESCRIPTION
Only clear dataholder cache on reading tree, might be a bit
controversial for tif images, but prevents entire tree read on every
slice of SWMR data

@gerring would you review and merge?