### PR TITLE
Modifications for defining number of threads/cores to run

### DIFF
--- a/org.eclipse.dawnsci.analysis.api/src/org/eclipse/dawnsci/analysis/api/processing/IOperationContext.java
+++ b/org.eclipse.dawnsci.analysis.api/src/org/eclipse/dawnsci/analysis/api/processing/IOperationContext.java
@@ -145,11 +145,30 @@ public interface IOperationContext {
 	public ExecutionType getExecutionType();
 	
 	/**
+	 * Sets the execution type for operations.
+	 * If the ExecutionType is set to PARALLEL all processors seen
+	 * by Runtime will be set as the number of available cores by
+	 * default. If the number of CPU cores to be set is to be defined 
+	 * implicitly this must be done after setting the execution type
 	 * 
 	 * @param executionType
 	 */
 	public void setExecutionType(ExecutionType executionType) ;
 
+	/**
+	 * 
+	 * @return number of cores.
+	 */
+	public int getNumberOfCores();
+	
+	/**
+	 * Sets the number of CPU cores to use.
+	 * Must be set after setting the execution type
+	 * 
+	 * @param numberOfCores
+	 */
+	public void setNumberOfCores(int numberOfCores) ;
+	
 	/**
 	 * Timeout in parallel mode.
 	 * @return timeout

--- a/org.eclipse.dawnsci.analysis.dataset/src/org/eclipse/dawnsci/analysis/dataset/slicer/Slicer.java
+++ b/org.eclipse.dawnsci.analysis.dataset/src/org/eclipse/dawnsci/analysis/dataset/slicer/Slicer.java
@@ -59,13 +59,14 @@ public class Slicer {
 		
 	}
 
-	public static void visitParallel(ISliceViewIterator iterator, final SliceVisitor visitor) throws Exception {
+	public static void visitParallel(ISliceViewIterator iterator, final SliceVisitor visitor, int nProcessors) throws Exception {
 
 		//Can't just farm out each slice to a separate thread, need to block when thread pool full,
 		//other wise there is the potential run out of memory from loading all the data before any is processed
 		
 		//use one less thread than processors, as we are using one for the rejectedhandler
-		int nProcessors = Math.max(Runtime.getRuntime().availableProcessors()-1,1);
+		nProcessors = nProcessors - 1;
+
 		BlockingQueue<Runnable> blockingQueue = new ArrayBlockingQueue<Runnable>(nProcessors);
 	    RejectedExecutionHandler rejectedExecutionHandler = new ThreadPoolExecutor.CallerRunsPolicy();
 	    final ExecutorService pool =  new ThreadPoolExecutor(nProcessors, nProcessors, 


### PR DESCRIPTION
Added a get/set-NumberOfCores routine to the IOperationContext as well as consumerate logic in the Slicer class to deal with changes to nProcessors