### PR TITLE
SCI-5975: ensure all fields in operation models are found

### DIFF
--- a/org.eclipse.dawnsci.analysis.api/src/org/eclipse/dawnsci/analysis/api/processing/model/ModelUtils.java
+++ b/org.eclipse.dawnsci.analysis.api/src/org/eclipse/dawnsci/analysis/api/processing/model/ModelUtils.java
@@ -17,16 +17,17 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class ModelUtils {
 
+	private ModelUtils() {
+		
+	}
 	
 	public static boolean isFileType(Class<? extends Object> clazz) {
 		if (File.class.isAssignableFrom(clazz))       return true;
@@ -37,32 +38,28 @@ public class ModelUtils {
 
 	public static OperationModelField getAnnotation(IOperationModel model, String fieldName) {
 		
-		try {
-			Field field = getField(model, fieldName);
-	        if (field!=null) {
-	        	OperationModelField anot = field.getAnnotation(OperationModelField.class);
-	        	if (anot!=null) {
-	        		return anot;
-	        	}
+		Field field = getField(model, fieldName);
+	    if (field!=null) {
+	    	OperationModelField anot = field.getAnnotation(OperationModelField.class);
+	    	if (anot!=null) {
+	    		return anot;
 	        }
-	        return null;
-	        
-		} catch (NoSuchFieldException | SecurityException e) {
-			e.printStackTrace();
-			return null;
-		}
-		
+	    }
+	    return null;
 	}
 	
-	public static Field getField(IOperationModel model, String fieldName) throws NoSuchFieldException, SecurityException {
+	public static Field getField(IOperationModel model, String fieldName) {
+		Class<?> klazz = model.getClass();
 		
-    	Field field;
-		try {
-			field = model.getClass().getDeclaredField(fieldName);
-		} catch (Exception ne) {
-			field = model.getClass().getSuperclass().getDeclaredField(fieldName);
-		}
-		return field;
+		// see remarks in getModelFields
+		do {
+			try {
+				return klazz.getDeclaredField(fieldName);
+			} catch (NoSuchFieldException | SecurityException e) {
+				klazz = klazz.getSuperclass();
+			}
+		} while(klazz != AbstractOperationModel.class && klazz != null);
+		return null;
 	}
 
 	
@@ -77,13 +74,22 @@ public class ModelUtils {
 		
 		// Decided not to use the obvious BeanMap here because class problems with
 		// GDA and we have to read annotations anyway.
-		final List<Field> allFields = new ArrayList<Field>(31);
+		final List<Field> allFields = new ArrayList<>(31);
+		
 		// exclude static and final fields!
-		allFields.addAll(Stream.of(model.getClass().getDeclaredFields()).filter(field -> !Modifier.isStatic(field.getModifiers()) && !Modifier.isFinal(field.getModifiers())).collect(Collectors.toList()));
-		allFields.addAll(Stream.of(model.getClass().getSuperclass().getDeclaredFields()).filter(field -> !Modifier.isStatic(field.getModifiers()) && !Modifier.isFinal(field.getModifiers())).collect(Collectors.toList()));
+		// go through the inheritance tree and stop when the class is 
+		// 	1) equal to AbstractOperationModel OR
+		//  2) there is no super class, meaning the class implements IOperationModel directly
+		
+		Class<?> klazz = model.getClass();
+		
+		do {
+			allFields.addAll(Stream.of(klazz.getDeclaredFields()).filter(field -> !Modifier.isStatic(field.getModifiers()) && !Modifier.isFinal(field.getModifiers())).collect(Collectors.toList()));
+			klazz = klazz.getSuperclass();
+		} while(klazz != AbstractOperationModel.class && klazz != null);
 		
 		// The returned descriptor
-		final List<ModelField> ret = new ArrayList<ModelField>();
+		final List<ModelField> ret = new ArrayList<>();
 		
 		// fields
 		for (Field field : allFields) {
@@ -99,26 +105,21 @@ public class ModelUtils {
 			}
 		}
 		
-		Collections.sort(ret, new Comparator<ModelField>() {
-			@Override
-			public int compare(ModelField o1, ModelField o2) {
-				OperationModelField an1 = ModelUtils.getAnnotation(o1.getModel(), o1.getName());
-				OperationModelField an2 = ModelUtils.getAnnotation(o2.getModel(), o2.getName());
-				
-				// It is legal for fields not to be annotated
-				if (an1!=null && an2 !=null) {
-					if (an1.fieldPosition() != Integer.MAX_VALUE && an2.fieldPosition() != Integer.MAX_VALUE) {
-						return (an1.fieldPosition() - an2.fieldPosition());
-					}
-					else if (an1.fieldPosition() != Integer.MAX_VALUE) {
-						return -1;
-					}
-					else if (an2.fieldPosition() != Integer.MAX_VALUE) {
-						return 1;
-					}
+		Collections.sort(ret, (o1, o2) -> {
+			OperationModelField an1 = ModelUtils.getAnnotation(o1.getModel(), o1.getName());
+			OperationModelField an2 = ModelUtils.getAnnotation(o2.getModel(), o2.getName());
+			
+			// It is legal for fields not to be annotated
+			if (an1!=null && an2 !=null) {
+				if (an1.fieldPosition() != Integer.MAX_VALUE && an2.fieldPosition() != Integer.MAX_VALUE) {
+					return (an1.fieldPosition() - an2.fieldPosition());
+				} else if (an1.fieldPosition() != Integer.MAX_VALUE) {
+					return -1;
+				} else if (an2.fieldPosition() != Integer.MAX_VALUE) {
+					return 1;
 				}
-				return o1.getDisplayName().toLowerCase().compareTo(o2.getDisplayName().toLowerCase());
 			}
+			return o1.getDisplayName().toLowerCase().compareTo(o2.getDisplayName().toLowerCase());
 		});
 		
 		return ret;


### PR DESCRIPTION
This commit fixes a bug that caused fields in parent model classes not to be detected if the parent was at least two levels removed from the examined model class.