### PR TITLE
Remove environments that we are not interested in

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,30 +83,9 @@
 			<version>${tycho-version}</version>
 			<configuration>
 				<environments>
-				
 					<environment>
 						<os>linux</os>
 						<ws>gtk</ws>
-						<arch>x86</arch>
-					</environment>
-					<environment>
-						<os>linux</os>
-						<ws>gtk</ws>
-						<arch>x86_64</arch>
-					</environment>
-					<environment>
-						<os>win32</os>
-						<ws>win32</ws>
-						<arch>x86</arch>
-					</environment>
-					<environment>
-						<os>win32</os>
-						<ws>win32</ws>
-						<arch>x86_64</arch>
-					</environment>
-					<environment>
-						<os>macosx</os>
-						<ws>cocoa</ws>
 						<arch>x86_64</arch>
 					</environment>
 				</environments>


### PR DESCRIPTION
If present, scanning tests can get the wrong SWT architecture, and fail

Signed-off-by: Matthew Webber <matthew.webber@diamond.ac.uk>