### PR TITLE
Switch null constructor to something sensible

### DIFF
--- a/org.eclipse.dawnsci.analysis.dataset/src/org/eclipse/dawnsci/analysis/dataset/roi/PolylineROI.java
+++ b/org.eclipse.dawnsci.analysis.dataset/src/org/eclipse/dawnsci/analysis/dataset/roi/PolylineROI.java
@@ -237,7 +237,7 @@ public class PolylineROI extends ROIBase implements IPolylineROI, Serializable {
 	@Override
 	public RectangularROI getBounds() {
 		if (bounds == null) {
-			bounds = new RectangularROI();
+			bounds = new RectangularROI(Double.NaN, Double.NaN, Double.NaN, Double.NaN, 0);
 			int imax = pts.size();
 			if (imax > 0) {
 				double[] max = new double[] { -Double.MAX_VALUE, -Double.MAX_VALUE };

--- a/org.eclipse.dawnsci.analysis.dataset/src/org/eclipse/dawnsci/analysis/dataset/roi/RectangularROI.java
+++ b/org.eclipse.dawnsci.analysis.dataset/src/org/eclipse/dawnsci/analysis/dataset/roi/RectangularROI.java
@@ -43,10 +43,10 @@ public class RectangularROI extends OrientableROIBase implements IRectangularROI
 	}
 
 	/**
-	 * Default has undefined start point and lengths
+	 * Default square of 100 pixels
 	 */
 	public RectangularROI() {
-		this(Double.NaN, Double.NaN, Double.NaN, Double.NaN, 0);
+		this(100, 0);
 	}
 
 	/**


### PR DESCRIPTION
We have some GUI code that uses reflections to instantiates ROIs but does not allow editing of fields with NaN values(!)

This is an alternative to commits 62635ae and d7a2ad0 for fixing DAQ-381