### PR TITLE
Prevent NPE when HDF5 object reference types are encountered

### DIFF
--- a/org.eclipse.dawnsci.hdf5/src/org/eclipse/dawnsci/hdf5/HDF5Utils.java
+++ b/org.eclipse.dawnsci.hdf5/src/org/eclipse/dawnsci/hdf5/HDF5Utils.java
@@ -1672,6 +1672,8 @@ public class HDF5Utils {
 				// TODO maybe convert to string dataset eventually
 				type.nEnum = H5.H5Tget_nmembers(nativeTypeId);
 				typeRepresentation = ENUM_SIZE_TO_HDF_TYPES.get(type.size);
+			} else if (tclass == HDF5Constants.H5T_REFERENCE) {
+				return null;
 			} else {
 				type.isVariableLength = tclass == HDF5Constants.H5T_VLEN;
 				typeRepresentation = getTypeRepresentation(nativeTypeId);


### PR DESCRIPTION
Datatype references are not handled at all so TODO add support for them