### PR TITLE
SCI-7211: add destroy() method to IOperation

### DIFF
--- a/org.eclipse.dawnsci.analysis.api/src/org/eclipse/dawnsci/analysis/api/processing/IOperation.java
+++ b/org.eclipse.dawnsci.analysis.api/src/org/eclipse/dawnsci/analysis/api/processing/IOperation.java
@@ -159,4 +159,11 @@ public interface IOperation<M extends IOperationModel, D extends OperationData> 
 	 * Called on each operation after each file is processed
 	 */
 	public void dispose();
+	
+	/**
+	 * Called when an operation gets removed from the pipeline in the Processing perspective 
+	 */
+	public default void destroy() {
+		// do nothing
+	}
 }


### PR DESCRIPTION
With an empty default implementation.

Should contain code to be executed when the IOperation is removed from the list of operations in the processing perspective for cleanup. This will be used to kill the background python interpreters generated by the Larch operations.

Signed-off-by: Tom Schoonjans <Tom.Schoonjans@diamond.ac.uk>